### PR TITLE
Filter out whitespace in bibfile cite key

### DIFF
--- a/checkcites.lua
+++ b/checkcites.lua
@@ -311,7 +311,7 @@ function getDataFromBibFiles(theBibFiles)
 			for currentLine in fileHandler:lines() do
 
                 -- if a reference is found
-				for reference in string.gmatch(currentLine, '@%w+{(.+),') do
+				for reference in string.gmatch(currentLine, '@%w+{%s*(.+),') do
 
                     -- insert the reference
 					table.insert(theReferences, reference)


### PR DESCRIPTION
Formatted bib entries with leading whitespace before the cite key
cause problems because the whitespace is extracted alongside the key.
This means bib files that are the output of tools such as bibtool are always
incorrectly processed.

There's a minimal example for reproducing this, along with output:
https://gist.github.com/4326728

Here's a quick example:

@Article{     foo,
  title        = {Bar},
  author   = {Doe, J.},
  journal  = {Nonexistent Journal},
  volume   = {1},
  number   = {1},
  pages        = {1--2},
  year     = {2012},
  publisher    = {Nonexistent publisher}
}

This would lead to the cite key being read as '   foo'. This change
updates the extraction regex to not capture any optional leading
whitespace, resulting in just 'foo'.
